### PR TITLE
Add HTTP/HTTPS options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
   "tslint.exclude": "**/test/**/*.ts",
   "typescript.tsdk": "node_modules/typescript/lib",
   "spellright.language": [
+    "en",
     "English (American)"
   ],
   "spellright.documentTypes": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### :zap: Added
+
+- Support for specifyting option `http.Agent` or `https.Agent` when creating a new `Connection`
+
 ## [1.0.7] - 2019-12-27
 
 ### :policeman: Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### :zap: Added
 
-- Support for specifyting option `http.Agent` or `https.Agent` when creating a new `Connection`
+- Support for specifying option `http.Agent` or `https.Agent` when creating a new `Connection`
 
 ## [1.0.7] - 2019-12-27
 

--- a/src/shared/Connection.ts
+++ b/src/shared/Connection.ts
@@ -3,7 +3,7 @@ import * as https from 'https';
 import { Protocol } from './Protocol';
 
 /**
- * Interface describing optional options for a connection.
+ * Interface describing options for a connection.
  */
 export interface Options {
     /**
@@ -38,7 +38,7 @@ export class Connection {
          */
         public readonly password: string,
         /**
-         * The optional options for the connection to the device.
+         * The options for the connection to the device.
          */
         public readonly options?: Options) {
     }

--- a/src/shared/Connection.ts
+++ b/src/shared/Connection.ts
@@ -1,4 +1,16 @@
+import * as http from 'http';
+import * as https from 'https';
 import { Protocol } from './Protocol';
+
+/**
+ * Interface describing optional options for a connection.
+ */
+export interface Options {
+    /**
+     * The HTTP or HTTPS agent used when opening the connection.
+     */
+    agent?: http.Agent | https.Agent;
+}
 
 /**
  * Class describing a connection to a device.
@@ -24,7 +36,11 @@ export class Connection {
         /**
          * The password.
          */
-        public readonly password: string) {
+        public readonly password: string,
+        /**
+         * The optional options for the connection to the device.
+         */
+        public readonly options?: Options) {
     }
 
     /**

--- a/src/shared/Request.ts
+++ b/src/shared/Request.ts
@@ -8,13 +8,14 @@ export abstract class Request {
     protected constructor(protected readonly connection: Connection) {
     }
 
-    protected async get(url): Promise<string> {
+    protected async get(url: string): Promise<string> {
         const options: rp.RequestPromiseOptions = {
             auth: {
                 user: this.connection.username,
                 pass: this.connection.password,
                 sendImmediately: false,
             },
+            agent: this.connection.options?.agent,
         };
 
         try {

--- a/test/shared/Connection.spec.ts
+++ b/test/shared/Connection.spec.ts
@@ -1,0 +1,51 @@
+import { Connection, Protocol } from "../../src";
+import * as http from 'http';
+import * as https from 'https';
+
+describe('connection', () => {
+
+    describe('#ctor(protocol, ...)', () => {
+
+        test('should return connection without options', () => {
+            // Act
+            const connection = new Connection(Protocol.Http, '1.2.3.4', 80, 'root', 'pass');
+
+            // Assert
+            expect(connection).toBeTruthy();
+        });
+
+        test('should return connection with http agent options', () => {
+            // Act
+            const connection = new Connection(
+                Protocol.Http,
+                '1.2.3.4',
+                80,
+                'root',
+                'pass',
+                {
+                    agent: new http.Agent()
+                });
+
+            // Assert
+            expect(connection).toBeTruthy();
+            expect(connection.options?.agent).toBeTruthy();
+        });
+
+        test('should return connection with https agent options', () => {
+            // Act
+            const connection = new Connection(
+                Protocol.Http,
+                '1.2.3.4',
+                80,
+                'root',
+                'pass',
+                {
+                    agent: new https.Agent()
+                });
+
+            // Assert
+            expect(connection).toBeTruthy();
+            expect(connection.options?.agent).toBeTruthy();
+        });
+    });
+});

--- a/test/shared/Connection.spec.ts
+++ b/test/shared/Connection.spec.ts
@@ -1,6 +1,6 @@
-import { Connection, Protocol } from "../../src";
 import * as http from 'http';
 import * as https from 'https';
+import { Connection, Protocol } from "../../src";
 
 describe('connection', () => {
 


### PR DESCRIPTION
Add options passed down to the HTTP/HTTPS module, lets start with `http.Agent` and `https.Agent`.